### PR TITLE
Moving gRPC load-balancing to Envoy

### DIFF
--- a/charts/mainflux/Chart.yaml
+++ b/charts/mainflux/Chart.yaml
@@ -6,7 +6,7 @@ name: mainflux
 description: Mainflux IoT Platform
 icon: https://avatars1.githubusercontent.com/u/13207490
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "0.9.1"
 home: https://www.mainflux.com
 sources:

--- a/charts/mainflux/templates/adapter_coap-deployment.yaml
+++ b/charts/mainflux/templates/adapter_coap-deployment.yaml
@@ -23,7 +23,7 @@ spec:
             - name: MF_NATS_URL
               value: nats://{{ .Release.Name }}-nats-client:4222
             - name: MF_THINGS_URL
-              value: {{ .Release.Name }}-things:8183
+              value: {{ .Release.Name }}-envoy:8183
             - name: MF_COAP_ADAPTER_LOG_LEVEL
               value: {{ default .Values.defaults.logLevel .Values.adapter_coap.logLevel }}
             - name: MF_COAP_ADAPTER_PORT

--- a/charts/mainflux/templates/adapter_http-deployment.yaml
+++ b/charts/mainflux/templates/adapter_http-deployment.yaml
@@ -27,7 +27,7 @@ spec:
             - name: MF_NATS_URL
               value: nats://{{ .Release.Name }}-nats-client:4222
             - name: MF_THINGS_URL
-              value: {{ .Release.Name }}-things:8183
+              value: {{ .Release.Name }}-envoy:8183
           image: "{{ default .Values.defaults.image.repository .Values.adapter_http.image.repository }}/http:{{ default .Values.defaults.image.tag .Values.adapter_http.image.tag }}"
           imagePullPolicy: {{ default .Values.defaults.image.pullPolicy .Values.adapter_http.image.pullPolicy }}
           name: {{ .Release.Name }}-adapter-http

--- a/charts/mainflux/templates/adapter_mqtt-deployment.yaml
+++ b/charts/mainflux/templates/adapter_mqtt-deployment.yaml
@@ -236,7 +236,7 @@ spec:
             - name: MF_NATS_URL
               value: nats://{{ .Release.Name }}-nats-client:4222
             - name: MF_THINGS_AUTH_GRPC_URL
-              value: http://{{ .Release.Name }}-things:8183
+              value: http://{{ .Release.Name }}-envoy:8183
             - name: DOCKER_VERNEMQ_PLUGINS__VMQ_PASSWD
               value: "off"
             - name: DOCKER_VERNEMQ_PLUGINS__VMQ_ACL

--- a/charts/mainflux/templates/adapter_ws-deployment.yaml
+++ b/charts/mainflux/templates/adapter_ws-deployment.yaml
@@ -23,7 +23,7 @@ spec:
             - name: MF_NATS_URL
               value: nats://{{ .Release.Name }}-nats-client:4222
             - name: MF_THINGS_URL
-              value: {{ .Release.Name }}-things:8183
+              value: {{ .Release.Name }}-envoy:8183
             - name: MF_WS_ADAPTER_LOG_LEVEL
               value: {{ default .Values.defaults.logLevel .Values.adapter_ws.logLevel }}
             - name: MF_WS_ADAPTER_PORT

--- a/charts/mainflux/templates/envoy.yaml
+++ b/charts/mainflux/templates/envoy.yaml
@@ -14,12 +14,50 @@ data:
         - filters:
           - name: envoy.tcp_proxy
             config:
-              stat_prefix: ingress_tcp
+              stat_prefix: adapter-mqtt
               cluster: adapter-mqtt
-              # access_log:
-              #   - name: envoy.file_access_log
-              #     config:
-              #       path: /dev/stdout
+      - address:
+          socket_address:
+            address: 0.0.0.0
+            port_value: 8181
+        filter_chains:
+        - filters:
+          - name: envoy.http_connection_manager
+            config:
+              codec_type: auto
+              stat_prefix: users
+              route_config:
+                name: users_route
+                virtual_hosts:
+                - name: users_service
+                  domains: ["*"]
+                  routes:
+                  - match: { prefix: "/" }
+                    route: { cluster: users }
+              http_filters:
+              - name: envoy.grpc_web
+              - name: envoy.router
+      - address:
+          socket_address:
+            address: 0.0.0.0
+            port_value: 8183
+        filter_chains:
+        - filters:
+          - name: envoy.http_connection_manager
+            config:
+              codec_type: auto
+              stat_prefix: things
+              route_config:
+                name: things_route
+                virtual_hosts:
+                - name: things_service
+                  domains: ["*"]
+                  routes:
+                  - match: { prefix: "/" }
+                    route: { cluster: things }
+              http_filters:
+              - name: envoy.grpc_web
+              - name: envoy.router
       clusters:
       - name: adapter-mqtt
         connect_timeout: 0.25s
@@ -29,6 +67,22 @@ data:
         - socket_address:
             address: {{ .Release.Name }}-adapter-mqtt
             port_value: 1883
+      - name: users
+        connect_timeout: 0.25s
+        type: strict_dns
+        lb_policy: round_robin
+        hosts:
+        - socket_address:
+            address: {{ .Release.Name }}-users-headless
+            port_value: 8181
+      - name: things
+        connect_timeout: 0.25s
+        type: strict_dns
+        lb_policy: round_robin
+        hosts:
+        - socket_address:
+            address: {{ .Release.Name }}-things-headless
+            port_value: 8183            
     admin:
       access_log_path: "/dev/null"
       address:
@@ -62,6 +116,10 @@ spec:
           ports:
             - containerPort: 1883 
               protocol: TCP
+            - containerPort: 8181 
+              protocol: TCP
+            - containerPort: 8183 
+              protocol: TCP
             - containerPort: 8001
               protocol: TCP
           volumeMounts:
@@ -87,6 +145,12 @@ spec:
     - port: 1883
       protocol: TCP
       name: mqtt
+    - port: 8181
+      protocol: TCP
+      name: users-grpc
+    - port: 8183
+      protocol: TCP
+      name: things-grpc
     - port: 8001
       protocol: TCP
       name: admin

--- a/charts/mainflux/templates/envoy.yaml
+++ b/charts/mainflux/templates/envoy.yaml
@@ -71,6 +71,7 @@ data:
         connect_timeout: 0.25s
         type: strict_dns
         lb_policy: round_robin
+        http2_protocol_options: {}
         hosts:
         - socket_address:
             address: {{ .Release.Name }}-users-headless
@@ -79,6 +80,7 @@ data:
         connect_timeout: 0.25s
         type: strict_dns
         lb_policy: round_robin
+        http2_protocol_options: {}
         hosts:
         - socket_address:
             address: {{ .Release.Name }}-things-headless

--- a/charts/mainflux/templates/things-deployment.yaml
+++ b/charts/mainflux/templates/things-deployment.yaml
@@ -45,7 +45,7 @@ spec:
             - name: MF_THINGS_SECRET
               value: c8ee60b5-1317-4b7c-adb3-c0d73f30959c
             - name: MF_USERS_URL
-              value: {{ .Release.Name }}-users:8181
+              value: {{ .Release.Name }}-envoy:8181
           image: "{{ default .Values.defaults.image.repository .Values.things.image.repository }}/things:{{ default .Values.defaults.image.tag .Values.things.image.tag }}"
           imagePullPolicy: {{ default .Values.defaults.image.pullPolicy .Values.things.image.pullPolicy }}
           name: {{ .Release.Name }}-things

--- a/charts/mainflux/templates/things-service.yaml
+++ b/charts/mainflux/templates/things-service.yaml
@@ -19,3 +19,23 @@ spec:
     - port: 8189
       protocol: TCP
       name: {{ .Release.Name }}-things-8189
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-things-headless
+spec:
+  selector:
+    app: {{ .Release.Name }}
+    component: things
+  ports:
+    - port: 8182
+      protocol: TCP
+      name: {{ .Release.Name }}-things-8182
+    - port: 8183
+      protocol: TCP
+      name: {{ .Release.Name }}-things-8183
+    - port: 8189
+      protocol: TCP
+      name: {{ .Release.Name }}-things-8189
+  clusterIP: None

--- a/charts/mainflux/templates/users-service.yaml
+++ b/charts/mainflux/templates/users-service.yaml
@@ -16,3 +16,20 @@ spec:
     - protocol: TCP
       port: 8181
       name: {{ .Release.Name }}-users-grpc
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-users-headless
+spec:
+  selector:
+    app: {{ .Release.Name }}
+    component: users
+  ports:
+    - protocol: TCP
+      port: 8180
+      name: {{ .Release.Name }}-users-http
+    - protocol: TCP
+      port: 8181
+      name: {{ .Release.Name }}-users-grpc
+  clusterIP: None


### PR DESCRIPTION
gRPC load-balancing should become a part of Envoy, as it "understands" gRPC.