### PR TITLE
NOISSUE - Override max_payload in NATS configuration

### DIFF
--- a/charts/mainflux/values.yaml
+++ b/charts/mainflux/values.yaml
@@ -78,6 +78,7 @@ nats:
     enabled: false
   clusterAuth:
     enabled: false
+  maxPayload: 268435456
 
 postgresql-users:
   name: postgresql-users


### PR DESCRIPTION
Change max payload to be same as in docker deployment of Mainflux

Signed-off-by: Ivan Milošević <iva@blokovi.com>