### PR TITLE
NOISSUE - Improve MQTT StatefulSet

### DIFF
--- a/charts/mainflux/templates/adapter_mqtt-deployment.yaml
+++ b/charts/mainflux/templates/adapter_mqtt-deployment.yaml
@@ -148,6 +148,7 @@ data:
 
         echo "erlang.distribution.port_range.minimum = 9100" >> /vernemq/etc/vernemq.conf
         echo "erlang.distribution.port_range.maximum = 9109" >> /vernemq/etc/vernemq.conf
+        # Localhost listeners so sidecar container inside pod have access to them
         echo "listener.tcp.default = 127.0.0.1:1883" >> /vernemq/etc/vernemq.conf
         echo "listener.ws.default = 127.0.0.1:8080" >> /vernemq/etc/vernemq.conf
         echo "listener.vmq.clustering = ${IP_ADDRESS}:44053" >> /vernemq/etc/vernemq.conf
@@ -330,11 +331,11 @@ spec:
             - name: MF_JAEGER_URL
               value: {{ .Release.Name }}-jaeger-operator-jaeger-agent:6831
             - name: MF_MQTT_ADAPTER_MQTT_TARGET_HOST
-              value: 127.0.0.1
+              value: localhost
             - name: MF_MQTT_ADAPTER_MQTT_TARGET_PORT
               value: "{{ .Values.mqtt.broker.mqtt_port }}"
             - name: MF_MQTT_ADAPTER_WS_TARGET_HOST
-              value: 127.0.0.1
+              value: localhost
             - name: MF_MQTT_ADAPTER_WS_TARGET_PORT    
               value: "{{ .Values.mqtt.broker.ws_port }}"
             - name: MF_MQTT_ADAPTER_THINGS_TIMEOUT

--- a/charts/mainflux/templates/adapter_mqtt-deployment.yaml
+++ b/charts/mainflux/templates/adapter_mqtt-deployment.yaml
@@ -149,8 +149,9 @@ data:
         echo "erlang.distribution.port_range.minimum = 9100" >> /vernemq/etc/vernemq.conf
         echo "erlang.distribution.port_range.maximum = 9109" >> /vernemq/etc/vernemq.conf
         # Localhost listeners so sidecar container inside pod have access to them
-        echo "listener.tcp.default = 127.0.0.1:1883" >> /vernemq/etc/vernemq.conf
-        echo "listener.ws.default = 127.0.0.1:8080" >> /vernemq/etc/vernemq.conf
+        LOCALHOST_IP_ADDRESS="--127.0.0.1"
+        echo "listener.tcp.default = ${LOCALHOST_IP_ADDRESS}:1883" >> /vernemq/etc/vernemq.conf
+        echo "listener.ws.default = ${LOCALHOST_IP_ADDRESS}:8080" >> /vernemq/etc/vernemq.conf
         echo "listener.vmq.clustering = ${IP_ADDRESS}:44053" >> /vernemq/etc/vernemq.conf
         echo "listener.http.metrics = ${IP_ADDRESS}:8888" >> /vernemq/etc/vernemq.conf
 

--- a/charts/mainflux/templates/adapter_mqtt-deployment.yaml
+++ b/charts/mainflux/templates/adapter_mqtt-deployment.yaml
@@ -149,7 +149,7 @@ data:
         echo "erlang.distribution.port_range.minimum = 9100" >> /vernemq/etc/vernemq.conf
         echo "erlang.distribution.port_range.maximum = 9109" >> /vernemq/etc/vernemq.conf
         # Localhost listeners so sidecar container inside pod have access to them
-        LOCALHOST_IP_ADDRESS="--127.0.0.1"
+        LOCALHOST_IP_ADDRESS="127.0.0.1"
         echo "listener.tcp.default = ${LOCALHOST_IP_ADDRESS}:1883" >> /vernemq/etc/vernemq.conf
         echo "listener.ws.default = ${LOCALHOST_IP_ADDRESS}:8080" >> /vernemq/etc/vernemq.conf
         echo "listener.vmq.clustering = ${IP_ADDRESS}:44053" >> /vernemq/etc/vernemq.conf

--- a/charts/mainflux/templates/adapter_mqtt-deployment.yaml
+++ b/charts/mainflux/templates/adapter_mqtt-deployment.yaml
@@ -148,8 +148,8 @@ data:
 
         echo "erlang.distribution.port_range.minimum = 9100" >> /vernemq/etc/vernemq.conf
         echo "erlang.distribution.port_range.maximum = 9109" >> /vernemq/etc/vernemq.conf
-        echo "listener.tcp.default = ${IP_ADDRESS}:1883" >> /vernemq/etc/vernemq.conf
-        echo "listener.ws.default = ${IP_ADDRESS}:8080" >> /vernemq/etc/vernemq.conf
+        echo "listener.tcp.default = 127.0.0.1:1883" >> /vernemq/etc/vernemq.conf
+        echo "listener.ws.default = 127.0.0.1:8080" >> /vernemq/etc/vernemq.conf
         echo "listener.vmq.clustering = ${IP_ADDRESS}:44053" >> /vernemq/etc/vernemq.conf
         echo "listener.http.metrics = ${IP_ADDRESS}:8888" >> /vernemq/etc/vernemq.conf
 
@@ -245,6 +245,12 @@ spec:
               value: "app={{ .Release.Name }},component=adapter-mqtt"
             - name: DOCKER_VERNEMQ_ALLOW_REGISTER_DURING_NETSPLIT
               value: "on"
+            - name: DOCKER_VERNEMQ_MAX_OFFLINE_MESSAGES
+              value: "-1"
+            - name: DOCKER_VERNEMQ_MAX_ONLINE_MESSAGES
+              value: "-1"
+            - name: DOCKER_VERNEMQ_MAX_INFLIGHT_MESSAGES
+              value: "0"
           image: "{{ default .Values.defaults.image.repository .Values.mqtt.broker.image.repository }}:{{ default .Values.defaults.image.tag .Values.mqtt.broker.image.tag }}"
           imagePullPolicy: {{ default .Values.defaults.image.pullPolicy .Values.mqtt.broker.image.pullPolicy }}
           name: {{ .Release.Name }}-adapter-mqtt
@@ -313,20 +319,22 @@ spec:
               value: "{{ .Values.mqtt.proxy.ws_port }}"
             - name: MF_MQTT_ADAPTER_ES_HOST
               value: {{ .Release.Name }}-redis-streams-master:6379
+            - name: MF_MQTT_ADAPTER_ES_URL
+              value: {{ .Release.Name }}-redis-streams-master:6379
             - name: MF_NATS_URL
               value: nats://{{ .Release.Name }}-nats-client:4222
             - name: MF_THINGS_URL
               value: {{ .Release.Name }}-envoy:8183
+            - name: MF_THINGS_AUTH_GRPC_URL
+              value:  {{ .Release.Name }}-envoy:8183
             - name: MF_JAEGER_URL
               value: {{ .Release.Name }}-jaeger-operator-jaeger-agent:6831
             - name: MF_MQTT_ADAPTER_MQTT_TARGET_HOST
-              value: {{ .Release.Name }}-adapter-mqtt
+              value: 127.0.0.1
             - name: MF_MQTT_ADAPTER_MQTT_TARGET_PORT
               value: "{{ .Values.mqtt.broker.mqtt_port }}"
-            - name: MF_MQTT_ADAPTER_MQTT_TARGET_HOST
-              value: {{ .Release.Name }}-adapter-mqtt
             - name: MF_MQTT_ADAPTER_WS_TARGET_HOST
-              value: {{ .Release.Name }}-adapter-mqtt
+              value: 127.0.0.1
             - name: MF_MQTT_ADAPTER_WS_TARGET_PORT    
               value: "{{ .Values.mqtt.broker.ws_port }}"
             - name: MF_MQTT_ADAPTER_THINGS_TIMEOUT


### PR DESCRIPTION
- fix mqtt-proxy to communicate only with VerneMQ in its same pod as sidecar
- remove default limitations of VerneMQ maximum number of [messagess in process](https://docs.vernemq.com/configuration/options#inflight-messages)

Signed-off-by: Ivan Milošević <iva@blokovi.com>