### PR TITLE
NOISSUE - Increase number of acceptor processes waiting to accept new connections for VerneMQ listeners

### DIFF
--- a/charts/mainflux/templates/adapter_mqtt-deployment.yaml
+++ b/charts/mainflux/templates/adapter_mqtt-deployment.yaml
@@ -154,6 +154,7 @@ data:
         echo "listener.ws.default = ${LOCALHOST_IP_ADDRESS}:8080" >> /vernemq/etc/vernemq.conf
         echo "listener.vmq.clustering = ${IP_ADDRESS}:44053" >> /vernemq/etc/vernemq.conf
         echo "listener.http.metrics = ${IP_ADDRESS}:8888" >> /vernemq/etc/vernemq.conf
+        echo "listener.nr_of_acceptors = 1000" >> /vernemq/etc/vernemq.conf
 
         echo "########## End ##########" >> /vernemq/etc/vernemq.conf
     fi


### PR DESCRIPTION
Increase default value for `listener.nr_of_acceptors` to `1000` in VerneMQ [configuration for listeners](https://docs.vernemq.com/configuration/listeners)

Signed-off-by: Ivan Milošević <iva@blokovi.com>