### PR TITLE
MF-2 - Remove vernemq.sh from mqtt StatefulSet

### DIFF
--- a/charts/mainflux/templates/adapter_mqtt-deployment.yaml
+++ b/charts/mainflux/templates/adapter_mqtt-deployment.yaml
@@ -34,170 +34,6 @@ spec:
       name: "{{ .Values.mqtt.proxy.ws_port }}"
   clusterIP: None
 ---
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: {{ .Release.Name }}-mqtt-verne
-data:
-  start_vernemq: |
-    #!/usr/bin/env bash
-    echo "Starting mqtt-verne ..."
-    sleep 5
-
-    IP_ADDRESS=$(ip -4 addr show ${DOCKER_NET_INTERFACE:-eth0} | grep -oE '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}' | sed -e "s/^[[:space:]]*//" | head -n 1)
-    IP_ADDRESS=${DOCKER_IP_ADDRESS:-${IP_ADDRESS}}
-
-    # Ensure the Erlang node name is set correctly
-    if env | grep "DOCKER_VERNEMQ_NODENAME" -q; then
-        sed -i.bak -r "s/-name VerneMQ@.+/-name VerneMQ@${DOCKER_VERNEMQ_NODENAME}/" /vernemq/etc/vm.args
-    else
-        if [ -n "$DOCKER_VERNEMQ_SWARM" ]; then
-            NODENAME=$(hostname -i)
-            sed -i.bak -r "s/VerneMQ@.+/VerneMQ@${NODENAME}/" /etc/vernemq/vm.args
-        else
-            sed -i.bak -r "s/-name VerneMQ@.+/-name VerneMQ@${IP_ADDRESS}/" /vernemq/etc/vm.args
-        fi
-    fi
-
-    if env | grep "DOCKER_VERNEMQ_DISCOVERY_NODE" -q; then
-        discovery_node=$DOCKER_VERNEMQ_DISCOVERY_NODE
-        if [ -n "$DOCKER_VERNEMQ_SWARM" ]; then
-            tmp=''
-            while [[ -z "$tmp" ]]; do
-                tmp=$(getent hosts tasks.$discovery_node | awk '{print $1}' | head -n 1)
-                sleep 1
-            done
-            discovery_node=$tmp
-        fi
-        if [ -n "$DOCKER_VERNEMQ_COMPOSE" ]; then
-            tmp=''
-            while [[ -z "$tmp" ]]; do
-                tmp=$(getent hosts $discovery_node | awk '{print $1}' | head -n 1)
-                sleep 1
-            done
-            discovery_node=$tmp
-        fi
-
-        sed -i.bak -r "/-eval.+/d" /vernemq/etc/vm.args 
-        echo "-eval \"vmq_server_cmd:node_join('VerneMQ@$discovery_node')\"" >> /vernemq/etc/vm.args
-    fi
-
-    # If you encounter "SSL certification error (subject name does not match the host name)", you may try to set DOCKER_VERNEMQ_KUBERNETES_INSECURE to "1".
-    insecure=""
-    if env | grep "DOCKER_VERNEMQ_KUBERNETES_INSECURE" -q; then
-        insecure="--insecure"
-    fi
-
-    if env | grep "DOCKER_VERNEMQ_DISCOVERY_KUBERNETES" -q; then
-        DOCKER_VERNEMQ_KUBERNETES_CLUSTER_NAME=${DOCKER_VERNEMQ_KUBERNETES_CLUSTER_NAME:-cluster.local}
-        # Let's get the namespace if it isn't set
-        DOCKER_VERNEMQ_KUBERNETES_NAMESPACE=${DOCKER_VERNEMQ_KUBERNETES_NAMESPACE:-`cat /var/run/secrets/kubernetes.io/serviceaccount/namespace`}
-        # Let's set our nodename correctly
-        VERNEMQ_KUBERNETES_SUBDOMAIN=${DOCKER_VERNEMQ_KUBERNETES_SUBDOMAIN:-$(curl -X GET $insecure --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt https://kubernetes.default.svc.$DOCKER_VERNEMQ_KUBERNETES_CLUSTER_NAME/api/v1/namespaces/$DOCKER_VERNEMQ_KUBERNETES_NAMESPACE/pods?labelSelector=$DOCKER_VERNEMQ_KUBERNETES_LABEL_SELECTOR -H "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" | jq '.items[0].spec.subdomain' | sed 's/"//g' | tr '\n' '\0')}
-        if [ $VERNEMQ_KUBERNETES_SUBDOMAIN == "null" ]; then
-            VERNEMQ_KUBERNETES_HOSTNAME=${MY_POD_NAME}.${DOCKER_VERNEMQ_KUBERNETES_NAMESPACE}.svc.${DOCKER_VERNEMQ_KUBERNETES_CLUSTER_NAME}
-        else
-            VERNEMQ_KUBERNETES_HOSTNAME=${MY_POD_NAME}.${VERNEMQ_KUBERNETES_SUBDOMAIN}.${DOCKER_VERNEMQ_KUBERNETES_NAMESPACE}.svc.${DOCKER_VERNEMQ_KUBERNETES_CLUSTER_NAME}
-        fi
-
-        sed -i.bak -r "s/VerneMQ@.+/VerneMQ@${VERNEMQ_KUBERNETES_HOSTNAME}/" /vernemq/etc/vm.args
-        # Hack into K8S DNS resolution (temporarily)
-        kube_pod_names=$(curl -X GET $insecure --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt https://kubernetes.default.svc.$DOCKER_VERNEMQ_KUBERNETES_CLUSTER_NAME/api/v1/namespaces/$DOCKER_VERNEMQ_KUBERNETES_NAMESPACE/pods?labelSelector=$DOCKER_VERNEMQ_KUBERNETES_LABEL_SELECTOR -H "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" | jq '.items[].spec.hostname' | sed 's/"//g' | tr '\n' ' ')
-        echo "=== Discovered kube_pod_names: $kube_pod_names"
-        for kube_pod_name in $kube_pod_names;
-        do
-            if [ $kube_pod_name == "null" ]
-                then
-                    echo "Kubernetes discovery selected, but no pods found. Maybe we're the first?"
-                    echo "Anyway, we won't attempt to join any cluster."
-                    break
-            fi
-            if [ $kube_pod_name != $MY_POD_NAME ]
-                then
-                    echo "Will join an existing Kubernetes cluster with discovery node at ${kube_pod_name}.${VERNEMQ_KUBERNETES_SUBDOMAIN}.${DOCKER_VERNEMQ_KUBERNETES_NAMESPACE}.svc.${DOCKER_VERNEMQ_KUBERNETES_CLUSTER_NAME}"
-                    echo "-eval \"vmq_server_cmd:node_join('VerneMQ@${kube_pod_name}.${VERNEMQ_KUBERNETES_SUBDOMAIN}.${DOCKER_VERNEMQ_KUBERNETES_NAMESPACE}.svc.${DOCKER_VERNEMQ_KUBERNETES_CLUSTER_NAME}')\"" >> /vernemq/etc/vm.args
-                    break
-            fi
-        done
-    fi
-
-    if [ -f /vernemq/etc/vernemq.conf.local ]; then
-        cp /vernemq/etc/vernemq.conf.local /vernemq/etc/vernemq.conf
-        sed -i -r "s/###IPADDRESS###/${IP_ADDRESS}/" /vernemq/etc/vernemq.conf
-    else
-        sed -i '/########## Start ##########/,/########## End ##########/d' /vernemq/etc/vernemq.conf
-
-        echo "########## Start ##########" >> /vernemq/etc/vernemq.conf
-
-        env | grep DOCKER_VERNEMQ | grep -v 'DISCOVERY_NODE\|KUBERNETES\|SWARM\|COMPOSE\|DOCKER_VERNEMQ_USER' | cut -c 16- | awk '{match($0,/^[A-Z0-9_]*/)}{print tolower(substr($0,RSTART,RLENGTH)) substr($0,RLENGTH+1)}' | sed 's/__/./g' >> /vernemq/etc/vernemq.conf
-
-        users_are_set=$(env | grep DOCKER_VERNEMQ_USER)
-        if [ ! -z "$users_are_set" ]; then
-            echo "vmq_passwd.password_file = /vernemq/etc/vmq.passwd" >> /vernemq/etc/vernemq.conf
-            touch /vernemq/etc/vmq.passwd
-        fi
-
-        for vernemq_user in $(env | grep DOCKER_VERNEMQ_USER); do
-            username=$(echo $vernemq_user | awk -F '=' '{ print $1 }' | sed 's/DOCKER_VERNEMQ_USER_//g' | tr '[:upper:]' '[:lower:]')
-            password=$(echo $vernemq_user | awk -F '=' '{ print $2 }')
-            /vernemq/bin/vmq-passwd /vernemq/etc/vmq.passwd $username <<EOF
-    $password
-    $password
-    EOF
-        done
-
-        echo "erlang.distribution.port_range.minimum = 9100" >> /vernemq/etc/vernemq.conf
-        echo "erlang.distribution.port_range.maximum = 9109" >> /vernemq/etc/vernemq.conf
-        # Localhost listeners so sidecar container inside pod have access to them
-        LOCALHOST_IP_ADDRESS="127.0.0.1"
-        echo "listener.tcp.default = ${LOCALHOST_IP_ADDRESS}:1883" >> /vernemq/etc/vernemq.conf
-        echo "listener.ws.default = ${LOCALHOST_IP_ADDRESS}:8080" >> /vernemq/etc/vernemq.conf
-        echo "listener.vmq.clustering = ${IP_ADDRESS}:44053" >> /vernemq/etc/vernemq.conf
-        echo "listener.http.metrics = ${IP_ADDRESS}:8888" >> /vernemq/etc/vernemq.conf
-        echo "listener.nr_of_acceptors = 1000" >> /vernemq/etc/vernemq.conf
-        echo "plugins.vmq_passwd = off" >> /vernemq/etc/vernemq.conf
-
-        echo "########## End ##########" >> /vernemq/etc/vernemq.conf
-    fi
-
-    echo "Checking configuration file..."
-    # Check configuration file
-
-    /vernemq/bin/vernemq config generate | tee /tmp/config.out | grep error
-
-    if [ $? -ne 1 ]; then
-        echo "configuration error, exit"
-        echo "$(cat /tmp/config.out)"
-        exit $?
-    fi
-
-    pid=0
-
-    # SIGUSR1-handler
-    siguser1_handler() {
-        echo "stopped"
-    }
-
-    # SIGTERM-handler
-    sigterm_handler() {
-        if [ $pid -ne 0 ]; then
-            # this will stop the VerneMQ process
-            /vernemq/bin/vmq-admin cluster leave node=VerneMQ@$IP_ADDRESS -k > /dev/null
-            wait "$pid"
-        fi
-        exit 143; # 128 + 15 -- SIGTERM
-    }
-
-    # Setup OS signal handlers
-    trap 'siguser1_handler' SIGUSR1
-    trap 'sigterm_handler' SIGTERM
-
-    # Start VerneMQ
-    /vernemq/bin/vernemq console -noshell -noinput $@
-    pid=$(ps aux | grep '[b]eam.smp' | awk '{print $2}')
-    wait $pid
-
----
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -215,20 +51,12 @@ spec:
         app: {{ .Release.Name}}
         component: adapter-mqtt
     spec:
-      volumes:
-        - name: start-vernemq
-          configMap:
-            name: {{ .Release.Name }}-mqtt-verne
-            defaultMode: 0755
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       securityContext:
         {{ toYaml .Values.mqtt.securityContext | nindent 8 }}      
       containers:
         - volumeMounts:
-            - name: start-vernemq
-              mountPath: /usr/sbin/start_vernemq
-              subPath: start_vernemq
             - name: data
               mountPath: /vernemq/data
           env:
@@ -260,6 +88,14 @@ spec:
               value: "-1"
             - name: DOCKER_VERNEMQ_MAX_INFLIGHT_MESSAGES
               value: "0"
+            - name: DOCKER_VERNEMQ_PLUGINS__VMQ_PASSWD
+              value: "off"
+            - name: DOCKER_VERNEMQ_LISTENER__NR_OF_ACCEPTORS
+              value: "1000"  
+            - name: DOCKER_VERNEMQ_LISTENER__TCP__LOCALHOST
+              value: "127.0.0.1:1883"
+            - name: DOCKER_VERNEMQ_LISTENER__WS__LOCALHOST
+              value: "127.0.0.1:8080"                 
           image: "{{ default .Values.defaults.image.repository .Values.mqtt.broker.image.repository }}:{{ default .Values.defaults.image.tag .Values.mqtt.broker.image.tag }}"
           imagePullPolicy: {{ default .Values.defaults.image.pullPolicy .Values.mqtt.broker.image.pullPolicy }}
           name: {{ .Release.Name }}-adapter-mqtt


### PR DESCRIPTION
Signed-off-by: Ivan Milošević <iva@blokovi.com>

Resolves #2 

By default helm charts is now using `mainflux/verne` image, that is build from Mainflux repo [Dockerfile](https://github.com/mainflux/mainflux/blob/master/docker/vernemq/Dockerfile) and it's copying [vernemq.sh](https://github.com/mainflux/mainflux/blob/master/docker/vernemq/bin/vernemq.sh) also from Mainflux repo. 
So, if there is something that should be configure in `vernemq.sh` as mentioned in issue #2 that can be done there instead again upload same script from helm charts.

VerneMQ tuning that are done in this script are moved to environment variables.
Because default listeners couldn't be changed from env vars (as stated [here](https://github.com/vernemq/docker-vernemq/issues/107)), new localhost listeners are added.