### PR TITLE
NOISSUE - Fix ingress 

### DIFF
--- a/charts/mainflux/templates/ingress.yaml
+++ b/charts/mainflux/templates/ingress.yaml
@@ -51,10 +51,6 @@ spec:
     - host: "{{ .Values.ingress.hostname }}"
       http:
         paths:
-          - path: /grafana/?(.*)
-            backend:
-              serviceName: grafana
-              servicePort: 3000
           - path: /(users)
             backend:
               serviceName: {{ .Release.Name }}-users
@@ -146,8 +142,8 @@ apiVersion: v1
 kind: ConfigMap
 data:
   # MQTT adapter:
-  1883: "{{ .Release.Namespace }}/{{ .Release.Name }}-envoy:1883:PROXY"
-  8883: "{{ .Release.Namespace }}/{{ .Release.Name }}-nginx-internal:8883:PROXY"
+  1883: "{{ .Release.Namespace }}/{{ .Release.Name }}-envoy:1883"
+  8883: "{{ .Release.Namespace }}/{{ .Release.Name }}-nginx-internal:8883"
 metadata:
   name: tcp-services
-  namespace: {{ .Release.Namespace }}
+  namespace: ingress-nginx

--- a/charts/mainflux/templates/nginx-internal.yaml
+++ b/charts/mainflux/templates/nginx-internal.yaml
@@ -447,9 +447,15 @@ spec:
             - mountPath: /etc/nginx/authorization.js
               name: nginx-authorization
               subPath: authorization.js
+<<<<<<< HEAD
             - mountPath: /etc/ssl/certs/ca.crt
               name: ca
               subPath: ca.crt
+=======
+            - mountPath: /etc/ssl/certs/ca.crt #lokacija gde da smesti secret
+              name: ca #naziv secret-a
+              subPath: ca.crt #key iz secret-a koji se koristi
+>>>>>>> efe778e... mTLS certs synchronized with mainflux core
             - mountPath: /etc/ssl/certs/mainflux-server
               name: mainflux-server
       dnsPolicy: ClusterFirst

--- a/charts/mainflux/templates/nginx-internal.yaml
+++ b/charts/mainflux/templates/nginx-internal.yaml
@@ -447,15 +447,9 @@ spec:
             - mountPath: /etc/nginx/authorization.js
               name: nginx-authorization
               subPath: authorization.js
-<<<<<<< HEAD
             - mountPath: /etc/ssl/certs/ca.crt
               name: ca
               subPath: ca.crt
-=======
-            - mountPath: /etc/ssl/certs/ca.crt #lokacija gde da smesti secret
-              name: ca #naziv secret-a
-              subPath: ca.crt #key iz secret-a koji se koristi
->>>>>>> efe778e... mTLS certs synchronized with mainflux core
             - mountPath: /etc/ssl/certs/mainflux-server
               name: mainflux-server
       dnsPolicy: ClusterFirst


### PR DESCRIPTION
Several changes in ingress resources:
- remove proxy protocol from listening on tcp-services (unnecessary complexity)
- move tcp-services to `ingress-nginx` namespace
- remove grafana path from ingress since there is no grafana installation in this repo
 
