### PR TITLE
NOISSUE - Fix parameter name for MongoDB

### DIFF
--- a/charts/mainflux/values.yaml
+++ b/charts/mainflux/values.yaml
@@ -297,7 +297,8 @@ twins:
   redisCachePort: 6379
 
 twins-db:
-  usePassword: false
+  auth:
+    enabled: false
 
 envoy:
   image:


### PR DESCRIPTION
MongoDB subchart from bitnami repo renamed `usePassword` parameter 

Signed-off-by: Ivan Milosevic <iva@blokovi.com>