### PR TITLE
NOISSUE - add helm value variable to support access to private registry

### DIFF
--- a/charts/mainflux/templates/adapter_coap-deployment.yaml
+++ b/charts/mainflux/templates/adapter_coap-deployment.yaml
@@ -37,6 +37,6 @@ spec:
           stdin: true
           tty: true
       imagePullSecrets:
-      - name: regcred
+      - name: {{ .Values.defaults.imagePullSecrets }}
       dnsPolicy: ClusterFirst
       restartPolicy: Always

--- a/charts/mainflux/templates/adapter_coap-deployment.yaml
+++ b/charts/mainflux/templates/adapter_coap-deployment.yaml
@@ -36,5 +36,7 @@ spec:
               protocol: UDP
           stdin: true
           tty: true
+      imagePullSecrets:
+      - name: regcred
       dnsPolicy: ClusterFirst
       restartPolicy: Always

--- a/charts/mainflux/templates/adapter_http-deployment.yaml
+++ b/charts/mainflux/templates/adapter_http-deployment.yaml
@@ -37,6 +37,6 @@ spec:
           stdin: true
           tty: true
       imagePullSecrets:
-      - name: regcred
+      - name: {{ .Values.defaults.imagePullSecrets }}
       dnsPolicy: ClusterFirst
       restartPolicy: Always

--- a/charts/mainflux/templates/adapter_http-deployment.yaml
+++ b/charts/mainflux/templates/adapter_http-deployment.yaml
@@ -36,5 +36,7 @@ spec:
               protocol: TCP
           stdin: true
           tty: true
+      imagePullSecrets:
+      - name: regcred
       dnsPolicy: ClusterFirst
       restartPolicy: Always

--- a/charts/mainflux/templates/adapter_lora-deployment.yaml
+++ b/charts/mainflux/templates/adapter_lora-deployment.yaml
@@ -40,7 +40,7 @@ spec:
           stdin: true
           tty: true
       imagePullSecrets:
-      - name: regcred
+      - name: {{ .Values.defaults.imagePullSecrets }}
       dnsPolicy: ClusterFirst
       restartPolicy: Always
 {{- end }}

--- a/charts/mainflux/templates/adapter_lora-deployment.yaml
+++ b/charts/mainflux/templates/adapter_lora-deployment.yaml
@@ -39,6 +39,8 @@ spec:
               protocol: TCP
           stdin: true
           tty: true
+      imagePullSecrets:
+      - name: regcred
       dnsPolicy: ClusterFirst
       restartPolicy: Always
 {{- end }}

--- a/charts/mainflux/templates/adapter_mqtt-statefulstet.yaml
+++ b/charts/mainflux/templates/adapter_mqtt-statefulstet.yaml
@@ -52,7 +52,7 @@ spec:
         component: mqtt
     spec:
       imagePullSecrets:
-      - name: regcred
+      - name: {{ .Values.defaults.imagePullSecrets }}
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       securityContext:

--- a/charts/mainflux/templates/adapter_mqtt-statefulstet.yaml
+++ b/charts/mainflux/templates/adapter_mqtt-statefulstet.yaml
@@ -51,6 +51,8 @@ spec:
         app: {{ .Release.Name}}
         component: mqtt
     spec:
+      imagePullSecrets:
+      - name: regcred
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       securityContext:

--- a/charts/mainflux/templates/adapter_opcua-deployment.yaml
+++ b/charts/mainflux/templates/adapter_opcua-deployment.yaml
@@ -48,7 +48,7 @@ spec:
           stdin: true
           tty: true
       imagePullSecrets:
-      - name: regcred
+      - name: {{ .Values.defaults.imagePullSecrets }}
       dnsPolicy: ClusterFirst
       restartPolicy: Always
 {{- end }}

--- a/charts/mainflux/templates/adapter_opcua-deployment.yaml
+++ b/charts/mainflux/templates/adapter_opcua-deployment.yaml
@@ -47,6 +47,8 @@ spec:
               protocol: TCP
           stdin: true
           tty: true
+      imagePullSecrets:
+      - name: regcred
       dnsPolicy: ClusterFirst
       restartPolicy: Always
 {{- end }}

--- a/charts/mainflux/templates/auth-deployment.yaml
+++ b/charts/mainflux/templates/auth-deployment.yaml
@@ -47,5 +47,7 @@ spec:
               protocol: TCP
             - containerPort: {{ .Values.auth.grpcPort }}
               protocol: TCP
+      imagePullSecrets:
+      - name: regcred
       dnsPolicy: ClusterFirst
       restartPolicy: Always

--- a/charts/mainflux/templates/auth-deployment.yaml
+++ b/charts/mainflux/templates/auth-deployment.yaml
@@ -48,6 +48,6 @@ spec:
             - containerPort: {{ .Values.auth.grpcPort }}
               protocol: TCP
       imagePullSecrets:
-      - name: regcred
+      - name: {{ .Values.defaults.imagePullSecrets }}
       dnsPolicy: ClusterFirst
       restartPolicy: Always

--- a/charts/mainflux/templates/bootstrap-deployment.yaml
+++ b/charts/mainflux/templates/bootstrap-deployment.yaml
@@ -51,6 +51,8 @@ spec:
           ports:
             - containerPort: {{ .Values.bootstrap.httpPort }}
               protocol: TCP
+      imagePullSecrets:
+      - name: regcred
       dnsPolicy: ClusterFirst
       restartPolicy: Always
 {{- end }}

--- a/charts/mainflux/templates/bootstrap-deployment.yaml
+++ b/charts/mainflux/templates/bootstrap-deployment.yaml
@@ -52,7 +52,7 @@ spec:
             - containerPort: {{ .Values.bootstrap.httpPort }}
               protocol: TCP
       imagePullSecrets:
-      - name: regcred
+      - name: {{ .Values.defaults.imagePullSecrets }}
       dnsPolicy: ClusterFirst
       restartPolicy: Always
 {{- end }}

--- a/charts/mainflux/templates/certs-deployment.yaml
+++ b/charts/mainflux/templates/certs-deployment.yaml
@@ -79,6 +79,8 @@ spec:
           ports:
             - containerPort: {{ .Values.certs.httpPort }}
               protocol: TCP
+      imagePullSecrets:
+      - name: regcred
       dnsPolicy: ClusterFirst
       restartPolicy: Always
 {{- end }}

--- a/charts/mainflux/templates/certs-deployment.yaml
+++ b/charts/mainflux/templates/certs-deployment.yaml
@@ -80,7 +80,7 @@ spec:
             - containerPort: {{ .Values.certs.httpPort }}
               protocol: TCP
       imagePullSecrets:
-      - name: regcred
+      - name: {{ .Values.defaults.imagePullSecrets }}
       dnsPolicy: ClusterFirst
       restartPolicy: Always
 {{- end }}

--- a/charts/mainflux/templates/influxdbreader-deployment.yaml
+++ b/charts/mainflux/templates/influxdbreader-deployment.yaml
@@ -46,7 +46,7 @@ spec:
           stdin: true
           tty: true
       imagePullSecrets:
-      - name: regcred
+      - name: {{ .Values.defaults.imagePullSecrets }}
       dnsPolicy: ClusterFirst
       restartPolicy: Always
 {{- end }}

--- a/charts/mainflux/templates/influxdbreader-deployment.yaml
+++ b/charts/mainflux/templates/influxdbreader-deployment.yaml
@@ -45,6 +45,8 @@ spec:
               protocol: TCP
           stdin: true
           tty: true
+      imagePullSecrets:
+      - name: regcred
       dnsPolicy: ClusterFirst
       restartPolicy: Always
 {{- end }}

--- a/charts/mainflux/templates/mongodbwriter-deployment.yaml
+++ b/charts/mainflux/templates/mongodbwriter-deployment.yaml
@@ -71,7 +71,7 @@ spec:
               name: mongodb-writer-config
               subPath: subjects.toml
       imagePullSecrets:
-      - name: regcred
+      - name: {{ .Values.defaults.imagePullSecrets }}
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       volumes:

--- a/charts/mainflux/templates/notifier_smtp-deployment.yaml
+++ b/charts/mainflux/templates/notifier_smtp-deployment.yaml
@@ -104,7 +104,7 @@ spec:
           stdin: true
           tty: true
       imagePullSecrets:
-      - name: regcred
+      - name: {{ .Values.defaults.imagePullSecrets }}
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       volumes:

--- a/charts/mainflux/templates/notifier_smtp-deployment.yaml
+++ b/charts/mainflux/templates/notifier_smtp-deployment.yaml
@@ -103,6 +103,8 @@ spec:
               subPath: config.toml                          
           stdin: true
           tty: true
+      imagePullSecrets:
+      - name: regcred
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       volumes:

--- a/charts/mainflux/templates/things-deployment.yaml
+++ b/charts/mainflux/templates/things-deployment.yaml
@@ -56,6 +56,6 @@ spec:
             - containerPort: {{ .Values.things.authHttpPort }}
               protocol: TCP
       imagePullSecrets:
-      - name: regcred
+      - name: {{ .Values.defaults.imagePullSecrets }}
       dnsPolicy: ClusterFirst
       restartPolicy: Always

--- a/charts/mainflux/templates/things-deployment.yaml
+++ b/charts/mainflux/templates/things-deployment.yaml
@@ -55,5 +55,7 @@ spec:
               protocol: TCP
             - containerPort: {{ .Values.things.authHttpPort }}
               protocol: TCP
+      imagePullSecrets:
+      - name: regcred
       dnsPolicy: ClusterFirst
       restartPolicy: Always

--- a/charts/mainflux/templates/twins-deployment.yaml
+++ b/charts/mainflux/templates/twins-deployment.yaml
@@ -43,6 +43,8 @@ spec:
           ports:
             - containerPort: {{ .Values.twins.httpPort }}
               protocol: TCP
+      imagePullSecrets:
+      - name: regcred
       dnsPolicy: ClusterFirst
       restartPolicy: Always
 {{- end }}

--- a/charts/mainflux/templates/twins-deployment.yaml
+++ b/charts/mainflux/templates/twins-deployment.yaml
@@ -44,7 +44,7 @@ spec:
             - containerPort: {{ .Values.twins.httpPort }}
               protocol: TCP
       imagePullSecrets:
-      - name: regcred
+      - name: {{ .Values.defaults.imagePullSecrets }}
       dnsPolicy: ClusterFirst
       restartPolicy: Always
 {{- end }}

--- a/charts/mainflux/templates/ui-deployment.yaml
+++ b/charts/mainflux/templates/ui-deployment.yaml
@@ -30,6 +30,6 @@ spec:
           tty: true
 
       imagePullSecrets:
-      - name: regcred
+      - name: {{ .Values.defaults.imagePullSecrets }}
       dnsPolicy: ClusterFirst
       restartPolicy: Always

--- a/charts/mainflux/templates/ui-deployment.yaml
+++ b/charts/mainflux/templates/ui-deployment.yaml
@@ -29,5 +29,7 @@ spec:
           stdin: true
           tty: true
 
+      imagePullSecrets:
+      - name: regcred
       dnsPolicy: ClusterFirst
       restartPolicy: Always

--- a/charts/mainflux/templates/users-deployment.yaml
+++ b/charts/mainflux/templates/users-deployment.yaml
@@ -68,7 +68,7 @@ spec:
               name: users-config
               subPath: email.tmpl
       imagePullSecrets:
-      - name: regcred
+      - name: {{ .Values.defaults.imagePullSecrets }}
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       volumes:

--- a/charts/mainflux/templates/users-deployment.yaml
+++ b/charts/mainflux/templates/users-deployment.yaml
@@ -67,6 +67,8 @@ spec:
             - mountPath: /email.tmpl
               name: users-config
               subPath: email.tmpl
+      imagePullSecrets:
+      - name: regcred
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       volumes:

--- a/charts/mainflux/values.yaml
+++ b/charts/mainflux/values.yaml
@@ -7,6 +7,7 @@ defaults:
     pullPolicy: "IfNotPresent"
     repository: "mainflux"
     tag: "0.12.0"
+    imagePullSecrets: ""
   # Replicas of MQTT adapter, NATS, Things, Envoy and Auth
   replicaCount: 3
   natsPort: 4222


### PR DESCRIPTION
When we are pulling images from some private repo we need to provide credentials
so when installing first create secret in kubernetes cluster
```
kubectl create secret docker-registry regcred --docker-server=registry.gitlab.com --docker-username=k8s --docker-password=xxxxxxxxx-G -n mf
```
then install with 
```
helm install  mainflux --create-namespace -n mf . \
...                            
  --set defaults.image.repository='registry.gitlab.com/org/project' \
  --set defaults.image.imagePullSecrets=regcred
```
