### PR TITLE
NOISSUE - fix imagePullSecretes

### DIFF
--- a/charts/mainflux/templates/adapter_coap-deployment.yaml
+++ b/charts/mainflux/templates/adapter_coap-deployment.yaml
@@ -40,9 +40,9 @@ spec:
               protocol: TCP
           stdin: true
           tty: true
-        {{- with .Values.imagePullSecrets }}
-          imagePullSecrets:
-            {{- toYaml . | nindent 12 }}
-        {{- end }}
+      {{- with .Values.defaults.image.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 12 }}
+      {{- end }}
       dnsPolicy: ClusterFirst
       restartPolicy: Always

--- a/charts/mainflux/templates/adapter_http-deployment.yaml
+++ b/charts/mainflux/templates/adapter_http-deployment.yaml
@@ -36,9 +36,9 @@ spec:
               protocol: TCP
           stdin: true
           tty: true
-        {{- with .Values.imagePullSecrets }}
-          imagePullSecrets:
-            {{- toYaml . | nindent 12 }}
-        {{- end }}
+      {{- with .Values.defaults.image.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 12 }}
+      {{- end }}
       dnsPolicy: ClusterFirst
       restartPolicy: Always

--- a/charts/mainflux/templates/adapter_lora-deployment.yaml
+++ b/charts/mainflux/templates/adapter_lora-deployment.yaml
@@ -39,10 +39,10 @@ spec:
               protocol: TCP
           stdin: true
           tty: true
-        {{- with .Values.imagePullSecrets }}
-          imagePullSecrets:
-            {{- toYaml . | nindent 12 }}
-        {{- end }}
+      {{- with .Values.defaults.image.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 12 }}
+      {{- end }}
       dnsPolicy: ClusterFirst
       restartPolicy: Always
 {{- end }}

--- a/charts/mainflux/templates/adapter_opcua-deployment.yaml
+++ b/charts/mainflux/templates/adapter_opcua-deployment.yaml
@@ -47,10 +47,10 @@ spec:
               protocol: TCP
           stdin: true
           tty: true
-        {{- with .Values.imagePullSecrets }}
-          imagePullSecrets:
-            {{- toYaml . | nindent 12 }}
-        {{- end }}
+      {{- with .Values.defaults.image.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 12 }}
+      {{- end }}
       dnsPolicy: ClusterFirst
       restartPolicy: Always
 {{- end }}

--- a/charts/mainflux/templates/auth-deployment.yaml
+++ b/charts/mainflux/templates/auth-deployment.yaml
@@ -59,9 +59,9 @@ spec:
               protocol: TCP
             - containerPort: {{ .Values.auth.grpcPort }}
               protocol: TCP
-        {{- with .Values.imagePullSecrets }}
-          imagePullSecrets:
-            {{- toYaml . | nindent 12 }}
-        {{- end }}
+      {{- with .Values.defaults.image.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 12 }}
+      {{- end }}
       dnsPolicy: ClusterFirst
       restartPolicy: Always

--- a/charts/mainflux/templates/bootstrap-deployment.yaml
+++ b/charts/mainflux/templates/bootstrap-deployment.yaml
@@ -55,10 +55,10 @@ spec:
           ports:
             - containerPort: {{ .Values.bootstrap.httpPort }}
               protocol: TCP
-        {{- with .Values.imagePullSecrets }}
-          imagePullSecrets:
-            {{- toYaml . | nindent 12 }}
-        {{- end }}
+      {{- with .Values.defaults.image.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 12 }}
+      {{- end }}
       dnsPolicy: ClusterFirst
       restartPolicy: Always
 {{- end }}

--- a/charts/mainflux/templates/certs-deployment.yaml
+++ b/charts/mainflux/templates/certs-deployment.yaml
@@ -83,10 +83,10 @@ spec:
           ports:
             - containerPort: {{ .Values.certs.httpPort }}
               protocol: TCP
-        {{- with .Values.imagePullSecrets }}
-          imagePullSecrets:
-            {{- toYaml . | nindent 12 }}
-        {{- end }}
+      {{- with .Values.defaults.image.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 12 }}
+      {{- end }}
       dnsPolicy: ClusterFirst
       restartPolicy: Always
 {{- end }}

--- a/charts/mainflux/templates/influxdbreader-deployment.yaml
+++ b/charts/mainflux/templates/influxdbreader-deployment.yaml
@@ -45,10 +45,10 @@ spec:
               protocol: TCP
           stdin: true
           tty: true
-        {{- with .Values.imagePullSecrets }}
-          imagePullSecrets:
-            {{- toYaml . | nindent 12 }}
-        {{- end }}
+      {{- with .Values.defaults.image.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 12 }}
+      {{- end }}
       dnsPolicy: ClusterFirst
       restartPolicy: Always
 {{- end }}

--- a/charts/mainflux/templates/influxdbwriter-deployment.yaml
+++ b/charts/mainflux/templates/influxdbwriter-deployment.yaml
@@ -68,6 +68,10 @@ spec:
             - mountPath: {{ .Values.influxdb.configPath }}
               name: influxdb-writer-config
               subPath: subjects.toml
+      {{- with .Values.defaults.image.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 12 }}
+      {{- end }}
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       volumes:

--- a/charts/mainflux/templates/mongodbreader-deployment.yaml
+++ b/charts/mainflux/templates/mongodbreader-deployment.yaml
@@ -45,6 +45,10 @@ spec:
               protocol: TCP
           stdin: true
           tty: true
+      {{- with .Values.defaults.image.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 12 }}
+      {{- end }}
       dnsPolicy: ClusterFirst
       restartPolicy: Always
 {{- end }}

--- a/charts/mainflux/templates/mongodbwriter-deployment.yaml
+++ b/charts/mainflux/templates/mongodbwriter-deployment.yaml
@@ -70,10 +70,10 @@ spec:
             - mountPath: {{ .Values.mongodb.configPath }}
               name: mongodb-writer-config
               subPath: subjects.toml
-        {{- with .Values.imagePullSecrets }}
-          imagePullSecrets:
-            {{- toYaml . | nindent 12 }}
-        {{- end }}
+      {{- with .Values.defaults.image.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 12 }}
+      {{- end }}
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       volumes:

--- a/charts/mainflux/templates/notifier_smtp-deployment.yaml
+++ b/charts/mainflux/templates/notifier_smtp-deployment.yaml
@@ -107,10 +107,10 @@ spec:
               subPath: config.toml
           stdin: true
           tty: true
-        {{- with .Values.imagePullSecrets }}
-          imagePullSecrets:
-            {{- toYaml . | nindent 12 }}
-        {{- end }}
+      {{- with .Values.defaults.image.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 12 }}
+      {{- end }}
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       volumes:

--- a/charts/mainflux/templates/things-deployment.yaml
+++ b/charts/mainflux/templates/things-deployment.yaml
@@ -59,9 +59,9 @@ spec:
               protocol: TCP
             - containerPort: {{ .Values.things.authHttpPort }}
               protocol: TCP
-        {{- with .Values.imagePullSecrets }}
-          imagePullSecrets:
-            {{- toYaml . | nindent 12 }}
-        {{- end }}
+      {{- with .Values.defaults.image.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 12 }}
+      {{- end }}
       dnsPolicy: ClusterFirst
       restartPolicy: Always

--- a/charts/mainflux/templates/twins-deployment.yaml
+++ b/charts/mainflux/templates/twins-deployment.yaml
@@ -43,10 +43,10 @@ spec:
           ports:
             - containerPort: {{ .Values.twins.httpPort }}
               protocol: TCP
-        {{- with .Values.imagePullSecrets }}
-          imagePullSecrets:
-            {{- toYaml . | nindent 12 }}
-        {{- end }}
+      {{- with .Values.defaults.image.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 12 }}
+      {{- end }}
       dnsPolicy: ClusterFirst
       restartPolicy: Always
 {{- end }}

--- a/charts/mainflux/templates/ui-deployment.yaml
+++ b/charts/mainflux/templates/ui-deployment.yaml
@@ -36,9 +36,9 @@ spec:
               protocol: TCP
           stdin: true
           tty: true
-        {{- with .Values.imagePullSecrets }}
-          imagePullSecrets:
-            {{- toYaml . | nindent 12 }}
-        {{- end }}
+      {{- with .Values.defaults.image.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 12 }}
+      {{- end }}
       dnsPolicy: ClusterFirst
       restartPolicy: Always

--- a/charts/mainflux/templates/users-deployment.yaml
+++ b/charts/mainflux/templates/users-deployment.yaml
@@ -71,10 +71,10 @@ spec:
             - mountPath: /email.tmpl
               name: users-config
               subPath: email.tmpl
-        {{- with .Values.imagePullSecrets }}
-          imagePullSecrets:
-            {{- toYaml . | nindent 12 }}
-        {{- end }}
+      {{- with .Values.defaults.image.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 12 }}
+      {{- end }}
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       volumes:


### PR DESCRIPTION
Signed-off-by: mteodor <mirko.teodorovic@gmail.com>

Correctly set `imagePullSecrets`, `imagePullSecrets` is on same level as `containers`

```yaml
    template:
      metadata:
        labels:
          app: nginx
      spec:
        hostNetwork: false
        containers:
        - name: nginx
         ...
          resources:
            limits: {}
        imagePullSecrets:
        - name: regcred
         ...
   ```