### PR TITLE
NOISSUE - change service ports

### DIFF
--- a/charts/mainflux/README.md
+++ b/charts/mainflux/README.md
@@ -39,18 +39,18 @@ The following table lists the configurable parameters and their default values.
 | nats.maxPayload                      | Maximum payload size in bytes that the NATS server will accept             | 268435456    |
 | nats.replicaCount                    | NATS replicas                                                              | 3            |
 | auth.dbPort                          | Auth service DB port                                                       | 5432         |
-| auth.grpcPort                        | Auth service gRPC port                                                     | 8181         |
-| auth.httpPort                        | Auth service HTTP port                                                     | 8189         |
+| auth.grpcPort                        | Auth service gRPC port                                                     | 7000         |
+| auth.httpPort                        | Auth service HTTP port                                                     | 9001         |
 | auth.secret                          | String used for signing tokens                                             | secret       |	
 | users.dbPort                         | Users service DB port                                                      | 5432         |
-| users.httpPort                       | Users service HTTP port                                                    | 8180         |
+| users.httpPort                       | Users service HTTP port                                                    | 9002         |
 | things.dbPort                        | Things service DB port                                                     | 5432         |
-| things.httpPort                      | Things service HTTP port                                                   | 8182         |
-| things.authGrpcPort                  | Things service Auth gRPC port                                              | 8183         |
-| things.authHttpPort                  | Things service Auth HTTP port                                              | 8989         |
+| things.httpPort                      | Things service HTTP port                                                   | 9000         |
+| things.authGrpcPort                  | Things service Auth gRPC port                                              | 7000         |
+| things.authHttpPort                  | Things service Auth HTTP port                                              | 9001        |
 | things.redisESPort                   | Things service Redis Event Store port                                      | 6379         |
 | things.redisCachePort                | Things service Redis Auth Cache port                                       | 6379         |
-| adapter_http.httpPort                | HTTP adapter port                                                          | 8185         |
+| adapter_http.httpPort                | HTTP adapter port                                                          | 8008         |
 | mqtt.adapter.mqttPort                | MQTT adapter port                                                          | 1884         |
 | mqtt.adapter.wsPort                  | MQTT adapter WS port                                                       | 8081         |
 | mqtt.broker.mqttPort                 | MQTT adapter broker port                                                   | 1883         |
@@ -62,23 +62,23 @@ The following table lists the configurable parameters and their default values.
 | ui.port                              | UI port                                                                    | 3000         |
 | bootstrap.enabled                    | Enable bootstrap service                                                   | false        |
 | bootstrap.dbPort                     | Bootstrap service DB port                                                  | 5432         |
-| bootstrap.httpPort                   | Bootstrap service HTTP port                                                | 8182         |
+| bootstrap.httpPort                   | Bootstrap service HTTP port                                                | 9013         |
 | bootstrap.redisESPort                | Bootstrap service Redis Event Store port                                   | 6379         |
 | influxdb.enabled                     | Enable InfluxDB reader & writer                                            | false        |
 | influxdb.dbPort                      | InfluxDB port                                                              | 8086         |
-| influxdb.writer.httpPort             | InfluxDB writer HTTP port                                                  | 8900         |
-| influxdb.reader.httpPort             | InfluxDB reader HTTP port                                                  | 8905         |
+| influxdb.writer.httpPort             | InfluxDB writer HTTP port                                                  | 9006         |
+| influxdb.reader.httpPort             | InfluxDB reader HTTP port                                                  | 9005         |
 | influxdb.backup.enabled              | Enable InfluxDB backup                                                     | false        |
 | influxdb.backup.cronjob.schedule     | Crontab style time schedule for backup execution                           | "0 2 * * *"  |
 | adapter_opcua.enabled                | Enable OPC-UA adapter                                                      | false        |
 | adapter_opcua.httpPort               | OPC-UA adapter HTTP port                                                   | 8188         |
 | adapter_opcua.redisRouteMapPort      | OPC-UA adapter Redis Auth Cache port                                       | 6379         |
 | adapter_lora.enabled                 | Enable LoRa adapter                                                        | false        |
-| adapter_lora.httpPort                | LoRa adapter HTTP port                                                     | 8187         |
+| adapter_lora.httpPort                | LoRa adapter HTTP port                                                     | 9017         |
 | adapter_lora.redisRouteMapPort       | LoRa adapter Redis Auth Cache port                                         | 6379         |
 | twins.enabled                        | Enable twins service                                                       | false        |
 | twins.dbPort                         | Twins service DB port                                                      | 27017        |
-| twins.httpPort                       | Twins service HTTP port                                                    | 9021         |
+| twins.httpPort                       | Twins service HTTP port                                                    | 9018         |
 | twins.redisCachePort                 | Twins service Redis Cache port                                             | 6379         |
 | certs.enabled                        | Enable certs service                                                       | false        |
 | notifier_smtp.enabled                | Enable SMTP notifier                                                       | false        |

--- a/charts/mainflux/values.yaml
+++ b/charts/mainflux/values.yaml
@@ -36,7 +36,7 @@ nginxInternal:
 
 adapter_http:
   image: {}
-  httpPort: 8185
+  httpPort: 8008
 
 adapter_coap:
   image: {}
@@ -56,7 +56,7 @@ adapter_opcua:
 adapter_lora:
   enabled: false
   image: {}
-  httpPort: 8187
+  httpPort: 9017
   messageUrl: "tcp://lora.mqtt.mainflux.io:1883"
   redisRouteMapPort: 6379
 
@@ -70,7 +70,7 @@ notifier_smtp:
   username: ""
   password: ""
   secret: ""
-  httpPort: 8906
+  httpPort: 9015
 
 mqtt:
   enabled: true
@@ -98,38 +98,38 @@ mqtt:
 users:
   image: {}
   dbPort: 5432
-  httpPort: 8180
+  httpPort: 9002
   adminEmail: "admin@example.com"
   adminPassword: "12345678"
 
 things:
   image: {}
   dbPort: 5432
-  httpPort: 8182
-  authGrpcPort: 8183
-  authHttpPort: 8989
+  httpPort: 9000
+  authGrpcPort: 7000
+  authHttpPort: 9001
   redisESPort: 6379
   redisCachePort: 6379
 
 auth:
   image: {}
   dbPort: 5432
-  grpcPort: 8181
-  httpPort: 8189
+  grpcPort: 7001
+  httpPort: 9020
   secret: "secret"
 
 bootstrap:
   enabled: false
   image: {}
   dbPort: 5432
-  httpPort: 8182
+  httpPort: 9013
   redisESPort: 6379
 
 certs:
   enabled: false
   image: {}
   dbPort: 5432
-  httpPort: 8204
+  httpPort: 9019
   logLevel: "info"
   sdkThingsPrefix: ""  
   encryptKey: ""
@@ -158,10 +158,10 @@ influxdb:
   dbPort: 8086
   writer:
     image: {}
-    httpPort: 8900
+    httpPort: 9006
   reader:
     image: {}
-    httpPort: 8905
+    httpPort: 9005
   database: "mainflux"
   authEnabled: true
   adminUser:
@@ -180,10 +180,10 @@ mongodb:
   dbPort: 27017
   writer:
     image: {}
-    httpPort: 8901
+    httpPort: 9008
   reader:
     image: {}
-    httpPort: 8904
+    httpPort: 9007
   database: "mainflux"
   authEnabled: true
   adminUser:
@@ -334,7 +334,7 @@ twins:
   enabled: false
   image: {}
   dbPort: 27017
-  httpPort: 9021
+  httpPort: 9018
   channelId: ""
   redisCachePort: 6379
 


### PR DESCRIPTION
### What does this do?
Change the default ports on services, 7XXX for grpc and 9XXX for http. Default adapter ports remain unchanges

### Which issue(s) does this PR fix/relate to?
None

### List any changes that modify/break current functionality
Updated ports:

| service | HTTP port | GRPC port |
| ---------- | --------------  | --------------- |
| Things | 9000 | |
| Things - Auth | 9001 | 7000 |
| Users | 9002 | |
|Cassandra-reader | 9003 | |
| Cassandra-writer | 9004 | |
| influxdb-reader | 9005   | |
| influxdb-writer | 9006   | |
| mongodb reader | 9007    | |
| mongodb writer | 9008    | |
| postgres-reader | 9009   | |
| postgres-writer | 9010   | |
| timescale-reader | 9011  | |
| timescale-writer | 9012  | |
| bootstrap | 9013         | |
| smpp-notifier | 9014     | |
| smtp-notifier | 9015     | |
| provision | 9016      | |   
| lora | 9017         | |     
| twins | 9018      | |
| certs | 9019 | |
| Auth | 9020 | 7001 |
| HTTP adapter | 8008|   |       

### Have you included tests for your changes?
No

### Did you document any new/modified functionality?
No

### Notes
