### PR TITLE
Update dependencies 

### DIFF
--- a/charts/mainflux/Chart.lock
+++ b/charts/mainflux/Chart.lock
@@ -4,48 +4,51 @@ dependencies:
   version: 4.3.7
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 10.2.3
+  version: 12.5.6
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 10.2.3
+  version: 12.5.6
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 10.2.3
+  version: 12.5.6
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 10.2.3
+  version: 12.5.6
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 10.2.3
+  version: 12.5.6
+- name: postgresql
+  repository: https://charts.bitnami.com/bitnami
+  version: 12.5.6
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 12.6.2
+  version: 17.11.3
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 12.6.2
+  version: 17.11.3
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 12.6.2
+  version: 17.11.3
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 12.6.2
+  version: 17.11.3
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 12.6.2
+  version: 17.11.3
 - name: influxdb
   repository: https://charts.bitnami.com/bitnami
-  version: 1.1.9
+  version: 5.6.1
 - name: mongodb
   repository: https://charts.bitnami.com/bitnami
-  version: 10.4.1
+  version: 13.15.1
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 10.2.3
+  version: 12.5.6
 - name: loki-stack
   repository: https://grafana.github.io/helm-charts
   version: 2.5.0
 - name: keto
   repository: https://k8s.ory.sh/helm/charts
   version: 0.21.7
-digest: sha256:d1d5b2bd36185bf632d5a08bf9f26495d93781d8c3ec335066afc4cc8cd6b9f6
-generated: "2022-02-07T17:15:53.130234981+01:00"
+digest: sha256:97e6d89fabcb8c94f42bc10089732231e176433dfc10f8cf746ac4cd5e21c5ea
+generated: "2023-06-08T14:13:49.890221+03:00"

--- a/charts/mainflux/Chart.yaml
+++ b/charts/mainflux/Chart.yaml
@@ -22,68 +22,68 @@ dependencies:
     version: "4.3.7"
     repository: "@stable"
   - name: postgresql
-    version: "10.2.3"
+    version: "12.5.6"
     repository: "@bitnami"
     alias: postgresqlthings
     condition: postgresqlthings.enabled
   - name: postgresql
-    version: "10.2.3"
+    version: "12.5.6"
     repository: "@bitnami"
     alias: postgresqlusers
     condition: postgresqlusers.enabled
   - name: postgresql
-    version: "10.2.3"
+    version: "12.5.6"
     repository: "@bitnami"
     alias: postgresqlauth
     condition: postgresqlauth.enabled
   - name: postgresql
-    version: "10.2.3"
+    version: "12.5.6"
     repository: "@bitnami"
     alias: postgresqlbootstrap
     condition: postgresqlbootstrap.enabled
   - name: postgresql
-    version: "10.2.3"
+    version: "12.5.6"
     repository: "@bitnami"
     alias: postgresqlcerts
     condition: postgresqlcerts.enabled
   - name: postgresql
-    version: "10.2.3"
+    version: "12.5.6"
     repository: "@bitnami"
     alias: postgresqlketo
     condition: postgresqlketo.enabled
   - name: redis
-    version: "12.6.2"
+    version: "17.11.3"
     repository: "@bitnami"
     alias: redis-streams
   - name: redis
-    version: "12.6.2"
+    version: "17.11.3"
     repository: "@bitnami"
     alias: redis-auth
   - name: redis
-    version: "12.6.2"
+    version: "17.11.3"
     repository: "@bitnami"
     alias: redis-mqtt
   - name: redis
-    version: "12.6.2"
+    version: "17.11.3"
     repository: "@bitnami"
     alias: redis-opcua
     condition: adapter_opcua.enabled
   - name: redis
-    version: "12.6.2"
+    version: "17.11.3"
     repository: "@bitnami"
     alias: redis-lora
     condition: adapter_lora.enabled
   - name: influxdb
-    version: "1.1.9"
+    version: "5.6.1"
     repository: "@bitnami"
     condition: influxdb.enabled
   - name: mongodb
-    version: "10.4.1"
+    version: "13.15.1"
     repository: "@bitnami"
     alias: twins-db
     condition: twins.enabled
   - name: postgresql
-    version: "10.2.3"
+    version: "12.5.6"
     repository: "@bitnami"
     alias: postgresqlnotifiersmtp
     condition: postgresqlnotifiersmtp.enabled


### PR DESCRIPTION
Update dependency chart versions to ones that are available. Specifically update Bitnami charts due to their index.yaml retention policy. See: https://github.com/bitnami/charts/issues/10539

This alone doesn't make this chart work with Kubernetes 1.25+ for changes like PodSecurityPolicy. See https://kubernetes.io/blog/2021/04/08/kubernetes-1-21-release-announcement/#podsecuritypolicy-deprecation